### PR TITLE
remove deprecate call

### DIFF
--- a/Controller/DefaultController.php
+++ b/Controller/DefaultController.php
@@ -77,7 +77,8 @@ class DefaultController extends Controller
 
     public function getLocalUrlDir($dir = 'mrapps_backend_files')
     {
-        return $this->getRequest()->getSchemeAndHttpHost() . '/uploads/' . $dir;
+        return $this->container->get('request_stack')->getCurrentRequest()->getSchemeAndHttpHost()
+            . '/uploads/' . $dir;
     }
 
     public function __topNavBarAction(Request $request)


### PR DESCRIPTION
`$this->getRequest()` e' diventato deprecato: adesso bisogna usare il servizio `$this->get('request_stack')` che restituisce la richiesta corrente con `$this->get('request_stack')->getCurrentRequest()`.
