### PR TITLE
Add entity merger service

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,5 +1,10 @@
 services:
 
+    mrapps.backend.merger:
+        class: Mrapps\BackendBundle\Services\EntityMerger
+        arguments:
+            - @mrapps.backend.translator
+
     mrapps.backend.translator:
         class: Mrapps\BackendBundle\Services\Translator
         arguments:

--- a/Services/EntityMerger.php
+++ b/Services/EntityMerger.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Mrapps\BackendBundle\Services;
+
+class EntityMerger
+{
+    private $row;
+
+    private $translator;
+
+    public function __construct(
+        Translator $translator
+    ) {
+        $this->translator = $translator;
+    }
+
+    public function setLocale($locale)
+    {
+        $this->translator->setLocale($locale);
+    }
+
+    public function initRow()
+    {
+        $this->row = [];
+    }
+
+    public function merge($entity, $normalFields, $transFields)
+    {
+        $index = count($this->row);
+
+        foreach ($normalFields as $attribute => $accessor) {
+            $this->row[$index][$attribute] = $entity->$accessor();
+        }
+
+        $entity = $this->translator->getTranslation($entity);
+        foreach ($transFields as $attribute => $accessor) {
+            $this->row[$index][$attribute] = $entity->$accessor();
+        }
+    }
+
+    public function getRow()
+    {
+        return $this->row;
+    }
+}


### PR DESCRIPTION
Queste e' un servizio utile per mergiare l'entity di base con quella tradotta (esempio Product + ProductLang di una certa lingua). L'entity tradotta viene recuperata dal Translator, che in questo progetto ha il compito, appunto, di recuperare l'entita' con le traduzioni in una certa lingua.
