### PR TITLE
Gestione multilingua in EntityMerger

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -6,6 +6,7 @@ services:
             - @mrapps.backend.translator
             - @security.token_storage
             - @request_stack
+            - @doctrine.orm.entity_manager
 
     mrapps.backend.translator:
         class: Mrapps\BackendBundle\Services\Translator

--- a/Services/EntityMerger.php
+++ b/Services/EntityMerger.php
@@ -5,6 +5,7 @@ namespace Mrapps\BackendBundle\Services;
 use Mrapps\BackendBundle\Exception\TranslationNotFoundException;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Doctrine\ORM\EntityManager;
 
 class EntityMerger
 {
@@ -15,20 +16,52 @@ class EntityMerger
     private $tokenStorage;
 
     private $requestStack;
+    
+    private $manager;
+    
+    private $defaultLocale;
+    
+    private $retrieveAllLanguages;
 
     public function __construct(
         Translator $translator,
         TokenStorage $tokenStorage,
-        RequestStack $requestStack
+        RequestStack $requestStack,
+        EntityManager $manager
     ) {
         $this->translator = $translator;
         $this->tokenStorage = $tokenStorage;
         $this->requestStack = $requestStack;
+        $this->manager = $manager;
+        $this->defaultLocale = null;
+        $this->retrieveAllLanguages = false;
+    }
+    
+    public function retrieveAllLanguages() {
+        $this->retrieveAllLanguages = true;
+    }
+    
+    public function dontRetrieveAllLanguages() {
+        $this->retrieveAllLanguages = false;
     }
 
-    public function setLocale($locale)
+
+    public function setDefaultLocale($locale)
     {
-        $this->translator->setLocale($locale);
+        $this->defaultLocale = $locale;
+        $this->setLocale($locale);
+    }
+    
+    public function setLocale($locale) {
+        
+        if(null === $this->defaultLocale)
+            $this->setDefaultLocale($locale);
+        else
+            $this->translator->setLocale($locale);
+    }
+    
+    public function resetLocale() {
+        $this->setLocale($this->defaultLocale);
     }
 
     public function initRow()
@@ -36,20 +69,36 @@ class EntityMerger
         $this->row = [];
     }
 
-    public function merge($entity, $normalFields, $transFields)
-    {
+    public function merge($entity, $normalFields, $transFields) {
+        
         $index = count($this->row);
-
+        
+        $this->mergeNormalFields($entity, $index, $normalFields);
+        
+        $this->mergeTransFields($entity, $index, $transFields);
+        
+        $this->mergeAllLanguagesFields($entity, $index, $transFields);
+    }
+    
+    private function mergeNormalFields($entity, $index, $normalFields) {
+        
+        foreach ($normalFields as $attribute => $accessor) {
+            $this->row[$index][$attribute] = $entity->$accessor();
+        }
+    }
+    
+    private function mergeTransFields($entity, $index, $transFields, $overrideLocale = null) {
+        
+        $locale = (null === $overrideLocale) ? $this->defaultLocale : $overrideLocale;
+        
+        $this->setLocale($locale);
+        
         try {
             $translatedEntity = $this->translator->getTranslation($entity);
         } catch (TranslationNotFoundException $exception) {
             return;
         }
-
-        foreach ($normalFields as $attribute => $accessor) {
-            $this->row[$index][$attribute] = $entity->$accessor();
-        }
-
+        
         if (!$translatedEntity) {
             throw new \RuntimeException(
                 'Translation not found for entity '
@@ -58,10 +107,15 @@ class EntityMerger
                 . $entity->getId()
             );
         }
-
+        
         foreach ($transFields as $attribute => $accessor) {
             if (is_string($accessor)) {
-                $this->row[$index][$attribute] = $translatedEntity->$accessor();
+                if(null !== $overrideLocale) {
+                    $this->row[$index]['_languages'][$locale][$attribute] = $translatedEntity->$accessor();
+                }else {
+                    $this->row[$index][$attribute] = $translatedEntity->$accessor();
+                }
+                
             } else {
                 $roles = $this->tokenStorage->getToken()->getRoles();
 
@@ -69,7 +123,11 @@ class EntityMerger
                 foreach ($roles as $role) {
                     if (isset($accessor[$role->getRole()])) {
                         $grantedAccessor = $accessor[$role->getRole()];
-                        $this->row[$index][$attribute] = $translatedEntity->$grantedAccessor();
+                        if(null !== $overrideLocale) {
+                            $this->row[$index]['_languages'][$locale][$attribute] = $translatedEntity->$grantedAccessor();
+                        }else {
+                            $this->row[$index][$attribute] = $translatedEntity->$grantedAccessor();
+                        }
                         $grantedAccessorFound = true;
                     }
                 }
@@ -77,14 +135,27 @@ class EntityMerger
                 if ($grantedAccessorFound == false) {
                     if (isset($accessor['*'])) {
                         $grantedAccessor = $accessor['*'];
-                        $this->row[$index][$attribute] = $translatedEntity->$grantedAccessor();
+                        if(null !== $overrideLocale) {
+                            $this->row[$index]['_languages'][$locale][$attribute] = $translatedEntity->$grantedAccessor();
+                        }else {
+                            $this->row[$index][$attribute] = $translatedEntity->$grantedAccessor();
+                        }
                     }
                 }
             }
-
         }
     }
-
+    
+    private function mergeAllLanguagesFields($entity, $index, $transFields) {
+        
+        if($this->retrieveAllLanguages) {
+            $availableLanguages = $this->manager->getRepository('MrappsBackendBundle:Language')->getAvailableLanguages();
+            foreach ($availableLanguages as $lang) {
+                $this->mergeTransFields($entity, $index, $transFields, $lang->getIsoCode());
+            }
+        }
+    }
+    
     public function getRow()
     {
         return $this->row;

--- a/Services/EntityMerger.php
+++ b/Services/EntityMerger.php
@@ -21,28 +21,27 @@ class EntityMerger
     
     private $defaultLocale;
     
-    private $retrieveAllLanguages;
+    private $areAllLanguagesRequested;
 
     public function __construct(
         Translator $translator,
         TokenStorage $tokenStorage,
-        RequestStack $requestStack,
-        EntityManager $manager
+        RequestStack $requestStack
     ) {
         $this->translator = $translator;
         $this->tokenStorage = $tokenStorage;
         $this->requestStack = $requestStack;
-        $this->manager = $manager;
+        $this->manager = $this->translator->getManager();
         $this->defaultLocale = null;
-        $this->retrieveAllLanguages = false;
+        $this->areAllLanguagesRequested = false;
     }
     
-    public function retrieveAllLanguages() {
-        $this->retrieveAllLanguages = true;
+    public function enableRequestAllLanguages() {
+        $this->areAllLanguagesRequested = true;
     }
     
-    public function dontRetrieveAllLanguages() {
-        $this->retrieveAllLanguages = false;
+    public function disableRequestAllLanguages() {
+        $this->areAllLanguagesRequested = false;
     }
 
 
@@ -148,7 +147,7 @@ class EntityMerger
     
     private function mergeAllLanguagesFields($entity, $index, $transFields) {
         
-        if($this->retrieveAllLanguages) {
+        if($this->areAllLanguagesRequested) {
             $availableLanguages = $this->manager->getRepository('MrappsBackendBundle:Language')->getAvailableLanguages();
             foreach ($availableLanguages as $lang) {
                 $this->mergeTransFields($entity, $index, $transFields, $lang->getIsoCode());

--- a/Services/Translator.php
+++ b/Services/Translator.php
@@ -58,7 +58,7 @@ class Translator
                 'Translation not found for '
                 . get_class($entity) . ' entity '
                 . ' with id ' . $entity->getId()
-                . ' in langage ' . $this->language->getIsoCode()
+                . ' in language ' . ($this->language!==null?$this->language->getIsoCode():'')
             );
         }
 

--- a/Services/Translator.php
+++ b/Services/Translator.php
@@ -28,7 +28,12 @@ class Translator
                 'isoCode' => $this->locale,
             ]);
     }
-
+    
+    public function getManager()
+    {
+        return $this->manager;
+    }
+    
     public function getTranslation(TranslatedEntity $entity)
     {
         if (!isset($this->locale)) {


### PR DESCRIPTION
Di default il servizio funziona come ora.

Se si chiama $em->retrieveAllLanguages() viene generata una chiave _languages con un array nella struttura:
[
    locale -> [ 'campo' => 'valore', 'campo' => 'valore', ... ]
    locale -> [ 'campo' => 'valore', 'campo' => 'valore', ... ]
]

es.

[
    'it' -> [ 'title' => 'Titolo italiano', 'description' => 'Descrizione italiana' ]
    'en' -> [ 'title' => 'English title', 'description' => 'English description' ]
]
