### PR TITLE
Fix favourite response

### DIFF
--- a/Responses/MrResponse.php
+++ b/Responses/MrResponse.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Mrapps\BackendBundle\Responses;
+
+final class MrResponse
+{
+    private $success;
+
+    private $message;
+
+    private $data;
+
+    private function __construct()
+    {
+    }
+
+    public static function build(array $params)
+    {
+        $this->data    = $params['data'];
+        $this->message = $params['message'];
+        $this->success = $params['success'];
+    }
+
+    public function getResponse()
+    {
+        return [
+            'success' => $this->success,
+            'data' => $this->data,
+            'message' => $this->message,
+        ];
+    }
+}

--- a/Responses/MrResponse.php
+++ b/Responses/MrResponse.php
@@ -2,31 +2,35 @@
 
 namespace Mrapps\BackendBundle\Responses;
 
+use Symfony\Component\HttpFoundation\JsonResponse;
+
 final class MrResponse
 {
-    private $success;
+    private $attributes;
 
-    private $message;
+    private static $attrToDefault = [
+        'data' => null,
+        'message' => '',
+        'success' => true,
+    ];
 
-    private $data;
-
-    private function __construct()
+    private function __construct(array $params)
     {
+        foreach (static::$attrToDefault as $name => $default) {
+            if (!isset($params[$name]) || $params[$name] == []) {
+                $params[$name] = static::$attrToDefault[$name];
+            }
+        }
+
+        $this->attributes = $params;
     }
 
-    public static function build(array $params)
+    public static function getJsonResponse(array $params)
     {
-        $this->data    = $params['data'];
-        $this->message = $params['message'];
-        $this->success = $params['success'];
-    }
+        $response = new self($params);
 
-    public function getResponse()
-    {
-        return [
-            'success' => $this->success,
-            'data' => $this->data,
-            'message' => $this->message,
-        ];
+        return new JsonResponse(
+            $response->attributes
+        );
     }
 }


### PR DESCRIPTION
`MrResponse::getJsonResponse(array $params)` restituisce un oggetto `Symfony\Component\HttpFoundation\JsonResponse()`. Per rendere tutte le risposte consistenti, il contenuto viene sempre costruito dentro al costruttore. Se un parametro non viene passato (per esempio in questo modo`MrResponse::getJsonResponse()`), viene usato il suo valore di default. La risposta di default e'

``` json
{
    "data" : null,
    "success" : true,
    "message" : ""
}
```
